### PR TITLE
v0.1.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Configure Open Ephys GUI
         run: |
           cd plugin-GUI
-          cmake -B Build -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTS=ON
+          cmake -B Build -A x64 -DBUILD_TESTS=ON
 
       - name: Build Open Ephys GUI
         run: |
@@ -59,7 +59,7 @@ jobs:
       - name: Configure plugin
         run: |
           cd plugin
-          cmake -B Build -G "Visual Studio 17 2022" -A x64 -DGUI_BASE_DIR="${{ github.workspace }}/plugin-GUI"
+          cmake -B Build -A x64 -DGUI_BASE_DIR="${{ github.workspace }}/plugin-GUI"
 
       - name: Build plugin
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the TriggeredAvg plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-06-18
+
+### Fixed
+
+- Null dereference in `handleAsyncUpdate` when the canvas is not open
+- Static local `lastSampleNumber` was shared across processor instances, causing incorrect trigger detection with multiple instances
+- Data race in cached plot-path rebuild — `DataStore` lock is now held for the full rebuild
+- Custom X-axis limits not clamped to the data collection window (`[-pre_ms, post_ms]`), silently producing a blank plot for out-of-range values (#8)
+- `x_min`, `x_max`, and `use_custom_x_limits` parameters not handled in `parameterValueChanged`, so programmatic changes (XML load, config messages) had no effect on the display
+
+### Changed
+
+- Replaced `assert(false)` in the `MSG_TRIGGER` broadcast path with a log warning so the plugin degrades gracefully on unexpected message types
+- Removed the dead 60 Hz polling timer in `TriggeredAvgCanvas` (display updates are now purely event-driven via `AsyncUpdater`)
+- Removed unused `post_ms` member from `GridDisplay`
+- Moved `SampleNumber` type alias to a dedicated `Types.h` to remove header coupling
+
 ## [0.1.0] - 2026-02-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build
+
+The plugin requires the Open Ephys GUI (`plugin-GUI`) to be checked out as a sibling directory (or set `GUI_BASE_DIR` env var). Expected layout:
+
+```
+Code/
+├── plugin-GUI/
+└── OEplugins/TriggeredAvg/
+```
+
+**Linux (primary platform):**
+```bash
+# Configure (the Build/ directory already exists)
+cmake -G "Unix Makefiles" -B Build
+# Build and install to plugin-GUI's plugins/ directory
+cmake --build Build -- -j$(nproc)
+cmake --install Build
+```
+
+**Format code:**
+```bash
+cmake --build Build --target format
+# Check only (no modifications):
+cmake --build Build --target format-check
+```
+
+## Tests
+
+Tests use Google Test (auto-fetched via FetchContent) and require the `plugin-GUI` headers but do not link against the GUI binary.
+
+```bash
+# Build tests
+cmake --build Build --target triggered-avg_tests
+
+# Run all tests
+ctest --test-dir Build --output-on-failure
+
+# Run a specific test by name pattern
+./Build/Tests/triggered-avg_tests --gtest_filter="*RingBuffer*"
+
+# Verbose / repeat
+./Build/Tests/triggered-avg_tests --gtest_verbose
+./Build/Tests/triggered-avg_tests --gtest_repeat=100
+```
+
+To add a new test: create `Tests/test_YourClass.cpp`, add it to `TRIGGERED_AVG_TEST_SOURCES` in `Tests/CMakeLists.txt`. When testing JUCE types, use `ScopedJuceInitialiser_GUI` in `SetUp`/`TearDown` (see `Tests/README.md`).
+
+## Architecture
+
+All code lives in the `TriggeredAverage` namespace. The plugin is a `GenericProcessor` that averages continuous signals around TTL events and/or broadcast messages.
+
+### Three-thread model
+
+| Thread | Entry point | Responsibility |
+|---|---|---|
+| Audio/processing | `TriggeredAvgNode::process` | Writes samples to ring buffer; detects triggers; enqueues `CaptureRequest` |
+| Data Collector | `DataCollector::run` | Reads pre/post windows from ring buffer; accumulates into `MultiChannelAverageBuffer`; signals GUI via `AsyncUpdater` |
+| GUI/message | `TriggeredAvgNode::handleAsyncUpdate`, `TriggeredAvgCanvas` | Repaints plots; handles user interaction |
+
+The audio thread is lock-free for data writes. The capture queue uses a `CriticalSection`. The `DataStore` uses a `std::recursive_mutex`.
+
+### Key classes
+
+- **`TriggeredAvgNode`** (`Source/TriggeredAvgNode.h`) — the `GenericProcessor` root; owns `MultiChannelRingBuffer`, `DataCollector`, `DataStore`, and `TriggerSources`.
+- **`MultiChannelRingBuffer`** (`Source/MultiChannelRingBuffer.h`) — ~10 s circular buffer with sample-accurate indexing; uses `writeLock` (recursive mutex) + atomics.
+- **`DataStore`** (`Source/DataCollector.h`) — maps `TriggerSource*` → `MultiChannelAverageBuffer` and `SingleTrialBufferJuce`; guards access with `GetLock()` before any read or write.
+- **`MultiChannelAverageBuffer`** — accumulates sum and sum-of-squares; computes running average and standard deviation on demand.
+- **`SingleTrialBuffer`** / **`SingleTrialBufferJuce`** — stores individual trials (raw pointer API in base; JUCE `AudioBuffer` convenience wrappers in the Juce subclass).
+- **`TriggerSource`** / **`TriggerSources`** — one `TriggerSource` per configured condition (TTL, message, or TTL+message); `TriggerSources` is the owning container.
+- **`CaptureRequest`** — POD queued from audio thread to Data Collector: `{triggerSource, triggerSample, preSamples, postSamples}`.
+
+### UI layer (`Source/Ui/`)
+
+- **`SinglePlotPanel`** — paints one channel's average (and optionally individual trials) for one trigger source; caches `Path` objects keyed on trial count and panel width to avoid redundant redraws.
+- **`GridDisplay`** — lays out a grid of `SinglePlotPanel`s.
+- **`PopupConfigurationWindow`** — per-panel settings (y/x limits, display mode, trial opacity).
+- **`DisplayMode`** — enum for average-only, trials-only, or overlay.
+
+### Undo/redo actions (`Source/TriggeredAvgActions.h`)
+
+All user-initiated trigger-source mutations (add, remove, rename, change TTL line, change type) go through `ProcessorAction` subclasses so the GUI undo stack tracks them.
+
+### Parameters
+
+Canonical parameter names live in `TriggeredAvgNode::ParameterNames` (e.g. `pre_ms`, `post_ms`, `x_min`, `use_custom_x_limits`). `parameterValueChanged` dispatches on these to update internal state and repaint.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,14 @@ set(PLUGIN_NAME TriggeredAvg)
 # Plugin version information
 set(PLUGIN_VERSION_MAJOR 0)
 set(PLUGIN_VERSION_MINOR 1)
-set(PLUGIN_VERSION_PATCH 0)
+set(PLUGIN_VERSION_PATCH 1)
 set(PLUGIN_VERSION "${PLUGIN_VERSION_MAJOR}.${PLUGIN_VERSION_MINOR}.${PLUGIN_VERSION_PATCH}")
 
 # Open Ephys GUI API version this plugin is built for
 set(OE_GUI_API_VERSION 10)
 # Optional: Set the GUI version if known (e.g., 0.6.5)
 # This can be auto-detected or manually set
-set(OE_GUI_VERSION "0.6.x" CACHE STRING "Open Ephys GUI version")
+set(OE_GUI_VERSION "1.0.x" CACHE STRING "Open Ephys GUI version")
 
 project(OE_PLUGIN_${PLUGIN_NAME} VERSION ${PLUGIN_VERSION})
 
@@ -20,16 +20,16 @@ project(OE_PLUGIN_${PLUGIN_NAME} VERSION ${PLUGIN_VERSION})
 option(BUILD_TESTS "Build the test suite" ON)
 
 if (NOT DEFINED GUI_BASE_DIR)
-    if (DEFINED ENV{GUI_BASE_DIR})
-        set(GUI_BASE_DIR $ENV{GUI_BASE_DIR})
-    else()
-        set(GUI_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../plugin-GUI)
-    endif()
+  if (DEFINED ENV{GUI_BASE_DIR})
+    set(GUI_BASE_DIR $ENV{GUI_BASE_DIR})
+  else()
+    set(GUI_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../plugin-GUI)
+  endif()
 endif()
 
 # ensure GUI folder exists
 if (NOT EXISTS ${GUI_BASE_DIR})
-    message(FATAL_ERROR "GUI_BASE_DIR does not exist: ${GUI_BASE_DIR}")
+  message(FATAL_ERROR "GUI_BASE_DIR does not exist: ${GUI_BASE_DIR}")
 endif()
 
 
@@ -37,10 +37,10 @@ get_filename_component(PROJECT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    set(LINUX 1)
-    if(NOT CMAKE_BUILD_TYPE)
-        set(CMAKE_BUILD_TYPE Debug)
-    endif()
+  set(LINUX 1)
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+  endif()
 endif()
 
 set(TRIGGERED_AVG_SOURCE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Source)
@@ -54,7 +54,7 @@ message(DEBUG "GUI_BIN_DIR will be: " ${GUI_BASE_DIR}/Build/[Debug|Release])
 # Setup clang-format target
 find_program(CLANG_FORMAT_EXE NAMES "clang-format")
 if(CLANG_FORMAT_EXE)
-    message(STATUS "clang-format found: ${CLANG_FORMAT_EXE}")
+  message(STATUS "clang-format found: ${CLANG_FORMAT_EXE}")
 endif()
 
 add_subdirectory(${TRIGGERED_AVG_SOURCE_PATH}) # sets TRIGGERED_AVG_HEADERS and TRIGGERED_AVG_SOURCES
@@ -63,15 +63,15 @@ MESSAGE(DEBUG "TRIGGERED_AVG_SOURCES: ${TRIGGERED_AVG_SOURCES}")
 
 # Get GUI_VERSION from the plugin-GUI CMakeLists.txt
 if(EXISTS "${GUI_BASE_DIR}/CMakeLists.txt")
-    # Create a temporary scope to read GUI_VERSION without building anything
-    file(READ "${GUI_BASE_DIR}/CMakeLists.txt" GUI_CMAKE_CONTENT)
-    string(REGEX MATCH "set\\(GUI_VERSION ([^)]+)\\)" _ "${GUI_CMAKE_CONTENT}")
-    if(CMAKE_MATCH_1)
-        string(STRIP "${CMAKE_MATCH_1}" GUI_VERSION_EXTRACTED)
-        string(REPLACE "\"" "" GUI_VERSION_EXTRACTED "${GUI_VERSION_EXTRACTED}")
-        set(OE_GUI_VERSION "${GUI_VERSION_EXTRACTED}")
-        message(STATUS "Detected Open Ephys GUI version: ${OE_GUI_VERSION}")
-    endif()
+  # Create a temporary scope to read GUI_VERSION without building anything
+  file(READ "${GUI_BASE_DIR}/CMakeLists.txt" GUI_CMAKE_CONTENT)
+  string(REGEX MATCH "set\\(GUI_VERSION ([^)]+)\\)" _ "${GUI_CMAKE_CONTENT}")
+  if(CMAKE_MATCH_1)
+    string(STRIP "${CMAKE_MATCH_1}" GUI_VERSION_EXTRACTED)
+    string(REPLACE "\"" "" GUI_VERSION_EXTRACTED "${GUI_VERSION_EXTRACTED}")
+    set(OE_GUI_VERSION "${GUI_VERSION_EXTRACTED}")
+    message(STATUS "Detected Open Ephys GUI version: ${OE_GUI_VERSION}")
+  endif()
 endif()
 
 # Generate version header
@@ -83,18 +83,18 @@ configure_file(
 
 # Add Windows resource file for DLL version info
 if(WIN32)
-    configure_file(
+  configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Version.rc.in
         ${CMAKE_CURRENT_BINARY_DIR}/Version.rc
         @ONLY
     )
-    set(RESOURCE_FILES ${CMAKE_CURRENT_BINARY_DIR}/Version.rc)
+  set(RESOURCE_FILES ${CMAKE_CURRENT_BINARY_DIR}/Version.rc)
 endif()
 
 if (APPLE)
-    add_library(${PLUGIN_NAME} MODULE ${TRIGGERED_AVG_SOURCES} ${RESOURCE_FILES})
+  add_library(${PLUGIN_NAME} MODULE ${TRIGGERED_AVG_SOURCES} ${RESOURCE_FILES})
 else()
-    add_library(${PLUGIN_NAME} SHARED ${TRIGGERED_AVG_SOURCES} ${RESOURCE_FILES})
+  add_library(${PLUGIN_NAME} SHARED ${TRIGGERED_AVG_SOURCES} ${RESOURCE_FILES})
 endif()
 
 target_sources(${PLUGIN_NAME}
@@ -143,80 +143,80 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
 
 
 if(MSVC)
-    target_link_libraries(${PLUGIN_NAME}
+  target_link_libraries(${PLUGIN_NAME}
   ${GUI_BIN_DIR}/open-ephys.lib
  )
 
-    target_compile_options(${PLUGIN_NAME} PRIVATE /sdl /W3 /MP4 /external:W0
+  target_compile_options(${PLUGIN_NAME} PRIVATE /sdl /W3 /MP4 /external:W0
                            /external:anglebrackets)
 
-    install(TARGETS ${PLUGIN_NAME} RUNTIME DESTINATION ${GUI_BIN_DIR}/plugins  CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
+  install(TARGETS ${PLUGIN_NAME} RUNTIME DESTINATION ${GUI_BIN_DIR}/plugins  CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
 
-    set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../libs)
+  set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../libs)
 elseif(LINUX)
-    target_link_libraries(${PLUGIN_NAME}
+  target_link_libraries(${PLUGIN_NAME}
   GL X11 Xext Xinerama asound dl freetype pthread rt
  )
-    set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
+  set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
   "-fvisibility=hidden -fPIC -rdynamic -Wl,-rpath,'$$ORIGIN/../shared'")
-    target_compile_options(${PLUGIN_NAME} PRIVATE -fPIC -rdynamic)
-    target_compile_options(${PLUGIN_NAME} PRIVATE -O3) #enable optimization for linux debug
+  target_compile_options(${PLUGIN_NAME} PRIVATE -fPIC -rdynamic)
+  target_compile_options(${PLUGIN_NAME} PRIVATE -O3) #enable optimization for linux debug
 
-    install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION ${GUI_BIN_DIR}/plugins)
+  install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION ${GUI_BIN_DIR}/plugins)
 elseif(APPLE)
-    set_target_properties(${PLUGIN_NAME} PROPERTIES
+  set_target_properties(${PLUGIN_NAME} PROPERTIES
         BUNDLE TRUE
         MACOSX_BUNDLE_BUNDLE_VERSION ${PLUGIN_VERSION}
         MACOSX_BUNDLE_SHORT_VERSION_STRING ${PLUGIN_VERSION}
     )
-    set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
+  set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
  "-undefined dynamic_lookup -rpath @loader_path/../../../../shared")
 
-    install(TARGETS ${PLUGIN_NAME} DESTINATION $ENV{HOME}/Library/Application\ Support/open-ephys/plugins-api10)
-    set(CMAKE_PREFIX_PATH /opt/local)
+  install(TARGETS ${PLUGIN_NAME} DESTINATION $ENV{HOME}/Library/Application\ Support/open-ephys/plugins-api10)
+  set(CMAKE_PREFIX_PATH /opt/local)
 endif()
 
 # Add clang-format target if clang-format is available
 if(CLANG_FORMAT_EXE)
-    # Collect all source files for formatting
-    file(GLOB_RECURSE ALL_SOURCE_FILES
+  # Collect all source files for formatting
+  file(GLOB_RECURSE ALL_SOURCE_FILES
         ${TRIGGERED_AVG_SOURCE_PATH}/*.cpp
         ${TRIGGERED_AVG_SOURCE_PATH}/*.h
     )
 
-    # Add format target
-    add_custom_target(
+  # Add format target
+  add_custom_target(
         format
         COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${ALL_SOURCE_FILES}
         COMMENT "Running clang-format on source files"
         VERBATIM
     )
 
-    # Add format-check target (doesn't modify files, just checks)
-    add_custom_target(
+  # Add format-check target (doesn't modify files, just checks)
+  add_custom_target(
         format-check
         COMMAND ${CLANG_FORMAT_EXE} --dry-run --Werror -style=file ${ALL_SOURCE_FILES}
         COMMENT "Checking code formatting with clang-format"
         VERBATIM
     )
 
-    message(STATUS "Added 'format' and 'format-check' targets")
+  message(STATUS "Added 'format' and 'format-check' targets")
 endif()
 
 # Add tests subdirectory if BUILD_TESTS is enabled
 if(BUILD_TESTS)
-    # Enable testing at the top level so CTest can discover tests
-    enable_testing()
+  # Enable testing at the top level so CTest can discover tests
+  enable_testing()
 
-    # Build the main GUI project with tests enabled to get gui_testable_source and test_helpers
-    # NOTE: This will also register GUI tests in CTest. To run only TriggeredAvg tests:
-    #   ctest -R "TriggeredAvg_tests" -C Release
-    # Or from the Tests subdirectory:
-    #   cd Build/Tests && ctest -C Release
-    set(BUILD_TESTS ON CACHE BOOL "Enable testing" FORCE)
-    set(OE_DONT_CHECK_BUILD_PATH TRUE CACHE BOOL "Disable build path check" FORCE)
-    add_subdirectory(${GUI_BASE_DIR} main_gui_build EXCLUDE_FROM_ALL)
+  # Build the main GUI project with tests enabled to get gui_testable_source and test_helpers
+  # NOTE: This will also register GUI tests in CTest. To run only TriggeredAvg tests:
+  #   ctest -R "TriggeredAvg_tests" -C Release
+  # Or from the Tests subdirectory:
+  #   cd Build/Tests && ctest -C Release
+  set(BUILD_TESTS ON CACHE BOOL "Enable testing" FORCE)
+  set(OE_DONT_CHECK_BUILD_PATH TRUE CACHE BOOL "Disable build path check" FORCE)
+  add_subdirectory(${GUI_BASE_DIR} main_gui_build EXCLUDE_FROM_ALL)
 
-    # Now add our plugin tests
-    add_subdirectory(Tests)
+  # Now add our plugin tests
+  add_subdirectory(Tests)
 endif()

--- a/Source/MultiChannelRingBuffer.h
+++ b/Source/MultiChannelRingBuffer.h
@@ -22,15 +22,13 @@
 
 */
 #pragma once
+#include "Types.h"
 #include <JuceHeader.h>
 #include <atomic>
 #include <mutex>
-#include <stdint.h>
 
 namespace TriggeredAverage
 {
-
-using SampleNumber = std::int64_t;
 
 enum class RingBufferReadResult : std::int_fast8_t
 {

--- a/Source/TriggeredAvgNode.cpp
+++ b/Source/TriggeredAvgNode.cpp
@@ -337,12 +337,9 @@ void TriggeredAvgNode::handleBroadcastMessage (const String& message, const int6
                 }
                 else if (source->type == TriggerType::MSG_TRIGGER)
                 {
-                    for (auto stream : getDataStreams())
-                    {
-                        const uint16 streamId = stream->getStreamId();
-                        // TODO: Do something
-                        assert (false);
-                    }
+                    // TODO: implement message-only triggering (use sysTimeMs to
+                    // estimate trigger sample and register a CaptureRequest)
+                    LOGD ("[TriggeredAvg] MSG_TRIGGER not yet implemented, ignoring message");
                 }
             }
         }

--- a/Source/TriggeredAvgNode.cpp
+++ b/Source/TriggeredAvgNode.cpp
@@ -400,8 +400,8 @@ void TriggeredAvgNode::handleTTLEvent (TTLEventPtr event)
 
 void TriggeredAvgNode::handleAsyncUpdate()
 {
-    // Called on message thread when new data arrives - directly refresh canvas
-    m_canvas->refresh();
+    if (m_canvas)
+        m_canvas->refresh();
 }
 
 void TriggeredAvgNode::initializeThreads()

--- a/Source/TriggeredAvgNode.cpp
+++ b/Source/TriggeredAvgNode.cpp
@@ -208,24 +208,25 @@ void TriggeredAvgNode::parameterValueChanged (Parameter* param)
             triggerAsyncUpdate();
         }
     }
+    else if (param->getName().equalsIgnoreCase (use_custom_x_limits))
+    {
+        if (m_canvas)
+            triggerAsyncUpdate();
+    }
+    else if (param->getName().equalsIgnoreCase (x_min) || param->getName().equalsIgnoreCase (x_max))
+    {
+        if (m_canvas)
+            triggerAsyncUpdate();
+    }
     else if (param->getName().equalsIgnoreCase (use_custom_y_limits))
     {
         if (m_canvas)
-        {
-            // Update canvas based on the toggle state
-            float value = param->getValue();
-            bool useCustomLimits = (value > 0.5f);
-            // The canvas will handle updating the UI and applying/resetting limits
             triggerAsyncUpdate();
-        }
     }
     else if (param->getName().equalsIgnoreCase (y_min) || param->getName().equalsIgnoreCase (y_max))
     {
         if (m_canvas)
-        {
-            // Update canvas with new Y-axis limits
             triggerAsyncUpdate();
-        }
     }
 }
 

--- a/Source/TriggeredAvgNode.cpp
+++ b/Source/TriggeredAvgNode.cpp
@@ -232,18 +232,11 @@ void TriggeredAvgNode::parameterValueChanged (Parameter* param)
 void TriggeredAvgNode::process (AudioBuffer<float>& buffer)
 {
     // For now: first stream only
-    static SampleNumber lastSampleNumber = 0;
     // TODO: Add handling of multiple streams (ring buffer per stream?)
     StreamId streamId = getDataStreams()[m_dataStreamIndex]->getStreamId();
-    auto timestamp = getFirstTimestampForBlock (streamId);
 
     SampleNumber firstSampleNumber = getFirstSampleNumberForBlock (streamId);
-    auto diff = firstSampleNumber - lastSampleNumber;
-    if (diff < 0)
-    {
-        lastSampleNumber += 0;
-    }
-    lastSampleNumber = firstSampleNumber;
+    m_lastSampleNumber = firstSampleNumber;
     if (! m_ringBuffer)
         return;
 

--- a/Source/TriggeredAvgNode.h
+++ b/Source/TriggeredAvgNode.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "TriggerSource.h"
+#include "Types.h"
 
 #include <ProcessorHeaders.h>
 #include <atomic>

--- a/Source/TriggeredAvgNode.h
+++ b/Source/TriggeredAvgNode.h
@@ -125,6 +125,7 @@ private:
     // Buffer parameters
     int m_ringBufferSize;
     std::atomic<bool> m_threadsInitialized;
+    SampleNumber m_lastSampleNumber = 0;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (TriggeredAvgNode)
 };

--- a/Source/Types.h
+++ b/Source/Types.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+
+namespace TriggeredAverage
+{
+using SampleNumber = std::int64_t;
+} // namespace TriggeredAverage

--- a/Source/Ui/GridDisplay.cpp
+++ b/Source/Ui/GridDisplay.cpp
@@ -167,11 +167,9 @@ void TriggeredAverage::GridDisplay::prepareToUpdate()
 
 void TriggeredAverage::GridDisplay::setWindowSizeMs (float pre_ms_, float post_ms_)
 {
-    post_ms = post_ms_;
-
     for (auto hist : panels)
     {
-        hist->setWindowSizeMs (pre_ms_, post_ms);
+        hist->setWindowSizeMs (pre_ms_, post_ms_);
     }
 }
 

--- a/Source/Ui/GridDisplay.h
+++ b/Source/Ui/GridDisplay.h
@@ -108,7 +108,6 @@ private:
 
     bool overlayConditions = false;
 
-    float post_ms;
     DisplayMode plotType = DisplayMode::INDIVIDUAL_TRACES;
 };
 

--- a/Source/Ui/TriggeredAvgCanvas.cpp
+++ b/Source/Ui/TriggeredAvgCanvas.cpp
@@ -644,9 +644,6 @@ TriggeredAvgCanvas::TriggeredAvgCanvas (TriggeredAvgNode* processor_)
     m_optionsBarHolder->setViewedComponent (m_optionsBar.get(), false);
     addAndMakeVisible (m_optionsBarHolder.get());
 
-    // Start timer for regular display updates (60 Hz)
-    // Note: Visualizer already inherits from Timer, so we use the inherited startTimer
-    startTimer (16); // ~60 FPS
 }
 
 void TriggeredAvgCanvas::refreshState() { resized(); }

--- a/Source/Ui/TriggeredAvgCanvas.cpp
+++ b/Source/Ui/TriggeredAvgCanvas.cpp
@@ -483,13 +483,32 @@ void OptionsBar::updateXLimits()
     float minX = xMinEditor->getText().getFloatValue();
     float maxX = xMaxEditor->getText().getFloatValue();
 
+    // Clamp to the actual data collection window so the plot always shows data
+    if (auto* triggeredAvgNode =
+            dynamic_cast<TriggeredAvgNode*> (canvas->getProcessor()))
+    {
+        const float windowMin = -triggeredAvgNode->getPreWindowSizeMs();
+        const float windowMax = triggeredAvgNode->getPostWindowSizeMs();
+        minX = std::max (minX, windowMin);
+        maxX = std::min (maxX, windowMax);
+    }
+
     if (minX >= maxX)
     {
-        // Invalid range - reset to defaults
-        xMinEditor->setText ("-50.0");
-        xMaxEditor->setText ("50.0");
-        minX = -50.0f;
-        maxX = 50.0f;
+        // Invalid range after clamping - reset to full window
+        if (auto* triggeredAvgNode =
+                dynamic_cast<TriggeredAvgNode*> (canvas->getProcessor()))
+        {
+            minX = -triggeredAvgNode->getPreWindowSizeMs();
+            maxX = triggeredAvgNode->getPostWindowSizeMs();
+        }
+        else
+        {
+            minX = -50.0f;
+            maxX = 50.0f;
+        }
+        xMinEditor->setText (String (minX));
+        xMaxEditor->setText (String (maxX));
     }
 
     display->setXLimits (minX, maxX);

--- a/Source/Ui/TriggeredAvgCanvas.cpp
+++ b/Source/Ui/TriggeredAvgCanvas.cpp
@@ -646,6 +646,15 @@ TriggeredAvgCanvas::TriggeredAvgCanvas (TriggeredAvgNode* processor_)
 
 }
 
+void TriggeredAvgCanvas::refresh()
+{
+    if (m_grid && m_dataStore)
+    {
+        auto lock = m_dataStore->GetLock();
+        m_grid->refresh();
+    }
+}
+
 void TriggeredAvgCanvas::refreshState() { resized(); }
 
 void TriggeredAvgCanvas::resized()

--- a/Source/Ui/TriggeredAvgCanvas.h
+++ b/Source/Ui/TriggeredAvgCanvas.h
@@ -108,14 +108,7 @@ public:
     TriggeredAvgCanvas (TriggeredAvgNode* processor);
     ~TriggeredAvgCanvas() override = default;
 
-    void refresh() override
-    {
-        if (m_grid && m_dataStore)
-        {
-            auto lock = m_dataStore->GetLock();
-            m_grid->refresh();
-        }
-    }
+    void refresh() override;
 
     void timerCallback() override {}
 

--- a/Source/Ui/TriggeredAvgCanvas.h
+++ b/Source/Ui/TriggeredAvgCanvas.h
@@ -117,12 +117,7 @@ public:
         }
     }
 
-    /** Timer callback - not needed since refresh is called directly on data updates */
-    void timerCallback() override
-    {
-        // No-op: refresh is now called directly from handleAsyncUpdate() when data arrives
-        // This eliminates 50 FPS polling
-    }
+    void timerCallback() override {}
 
     /** Called when the Visualizer's tab becomes visible after being hidden .*/
     void refreshState() override;

--- a/Source/Ui/TriggeredAvgCanvas.h
+++ b/Source/Ui/TriggeredAvgCanvas.h
@@ -110,9 +110,11 @@ public:
 
     void refresh() override
     {
-        // Directly refresh when called (from async update when data changes)
-        if (m_grid)
+        if (m_grid && m_dataStore)
+        {
+            auto lock = m_dataStore->GetLock();
             m_grid->refresh();
+        }
     }
 
     /** Timer callback - not needed since refresh is called directly on data updates */


### PR DESCRIPTION
 ## [0.1.1] - 2026-06-18

### Fixed

- Null dereference in `handleAsyncUpdate` when the canvas is not open
- Static local `lastSampleNumber` was shared across processor instances, causing incorrect trigger detection with multiple instances
- Data race in cached plot-path rebuild — `DataStore` lock is now held for the full rebuild
- Custom X-axis limits not clamped to the data collection window (`[-pre_ms, post_ms]`), silently producing a blank plot for out-of-range values (#8)
- `x_min`, `x_max`, and `use_custom_x_limits` parameters not handled in `parameterValueChanged`, so programmatic changes (XML load, config messages) had no effect on the display

### Changed

- Replaced `assert(false)` in the `MSG_TRIGGER` broadcast path with a log warning so the plugin degrades gracefully on unexpected message types
- Removed the dead 60 Hz polling timer in `TriggeredAvgCanvas` (display updates are now purely event-driven via `AsyncUpdater`)
- Removed unused `post_ms` member from `GridDisplay`
- Moved `SampleNumber` type alias to a dedicated `Types.h` to remove header coupling
